### PR TITLE
Fix: add missing constants in settings form

### DIFF
--- a/src/applications/cosmere-settings-form.js
+++ b/src/applications/cosmere-settings-form.js
@@ -1,3 +1,5 @@
+import { TEMPLATE_PATHS,MODULE_ID } from "../utils/constants";
+
 export class CosmereSettingsForm extends FormApplication {
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {


### PR DESCRIPTION
Import missing MODULE_ID and TEMPLATE_PATHS to cosmere-settings-form.js